### PR TITLE
feat: sms페이지 완성 및 path 완성

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -3,6 +3,7 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import GlobalStyles from './styles/GlobalStyles';
 
 import Home from './pages/home';
+import Sms from './pages/sms';
 
 export default function Router() {
   return (
@@ -12,6 +13,7 @@ export default function Router() {
         <Route path='/' element={<Home />} />
         <Route path='/manage' element={<Home />} />
         <Route path='/manage/attendance/:grade/:class' element={<Home />} />
+        <Route path='/manage/attendance/:grade/:class/sms' element={<Sms />} />
         <Route path='/manage/attendance/:grade' element={<Home />} />
         <Route path='/manage/attendance' element={<Home />} />
         <Route path='/manage/achievement' element={<Home />} />

--- a/src/components/layout/Layout.styles.tsx
+++ b/src/components/layout/Layout.styles.tsx
@@ -3,6 +3,6 @@ import styled from 'styled-components';
 export const Layout = styled.div`
   display: flex;
   margin-top: 7rem;
-  width: 100vh;
+  width: 100vw;
   height: 100vh;
 `;

--- a/src/components/managesidebar/Attendance.tsx
+++ b/src/components/managesidebar/Attendance.tsx
@@ -37,13 +37,13 @@ function Attendance() {
   const [selectedClass, setSelectedClass] = useState<string>(className || '');
 
   const handleGradeClick = (grade: number) => {
-    navigate(`/manage/attendance/${grade}`);
+    navigate(`/manage/attendance/${grade}학년`);
     setSelectedGrade(grade);
     setSelectedClass('');
   };
 
   const handleClassClick = (grade: number, className: string) => {
-    navigate(`/manage/attendance/${grade}/${className}`);
+    navigate(`/manage/attendance/${grade}학년/${className}`);
     setSelectedClass(className);
   };
 
@@ -52,11 +52,8 @@ function Attendance() {
       <S.AttendanceWrapper>
         <S.AttendanceBtn>전체학생</S.AttendanceBtn>
         {gradeData.map((data, index) => (
-          <S.ManageWrapper>
-            <S.GradeWrapper
-              key={data.grade}
-              onClick={() => handleGradeClick(data.grade)}
-            >
+          <S.ManageWrapper key={data.grade + index}>
+            <S.GradeWrapper onClick={() => handleGradeClick(data.grade)}>
               <S.Grade>
                 <S.Icon
                   src={selectedGrade === data.grade ? downArrow : rightArrow}
@@ -72,7 +69,7 @@ function Attendance() {
             </S.GradeWrapper>
             {data.class.map((classData) => (
               <S.ClassWrapper
-                key={classData.class}
+                key={classData.class + index}
                 $isSelected={data.grade === selectedGrade}
                 onClick={() => handleClassClick(data.grade, classData.class)}
               >

--- a/src/components/managesidebar/Attendance.tsx
+++ b/src/components/managesidebar/Attendance.tsx
@@ -33,7 +33,9 @@ function Attendance() {
     class?: string;
   }>();
   const navigate = useNavigate();
-  const [selectedGrade, setSelectedGrade] = useState<number>(Number(grade));
+  const [selectedGrade, setSelectedGrade] = useState<number>(
+    Number(grade?.replace(/[^0-9]/g, ''))
+  );
   const [selectedClass, setSelectedClass] = useState<string>(className || '');
 
   const handleGradeClick = (grade: number) => {

--- a/src/components/managesidebar/ManageSidebar.styles.tsx
+++ b/src/components/managesidebar/ManageSidebar.styles.tsx
@@ -4,10 +4,12 @@ export const ManageSidebarWrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 24rem;
+  min-width: 24rem;
   height: calc(100vh - 7rem);
   background: var(--color-white);
   padding: 3.5rem 0rem;
   background: #f2f5fc;
+  overflow-y: auto;
 `;
 
 export const SidebarItem = styled.div<{ $isSelected?: boolean }>`

--- a/src/components/path/Path.styles.tsx
+++ b/src/components/path/Path.styles.tsx
@@ -1,0 +1,21 @@
+import styled from 'styled-components';
+
+export const PathWrapper = styled.ul`
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  :last-child {
+    color: var(--color-black);
+  }
+`;
+
+export const PathItem = styled.li`
+  color: #7d7d7d;
+  font-size: 1.6rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 1.792rem;
+  list-style: none;
+  white-space: nowrap;
+  height: 1.792rem;
+`;

--- a/src/components/path/index.tsx
+++ b/src/components/path/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import * as S from './Path.styles';
+
+const pathMappings: Record<string, string> = {
+  manage: '학생관리',
+  attendance: '출석',
+  sms: 'SMS',
+  studentinfo: '학생정보',
+  list: '학생목록',
+  register: '학생등록',
+  achievement: '성적관리',
+};
+
+function Path() {
+  const location = useLocation();
+
+  const pathItems = location.pathname
+    .split('/')
+    .filter((segment) => segment)
+    .map((segment) => {
+      const decodedSegment = decodeURIComponent(segment);
+      return pathMappings[decodedSegment] || decodedSegment;
+    });
+
+  return (
+    <S.PathWrapper>
+      <S.PathWrapper>
+        {pathItems.map((item, index) => (
+          <React.Fragment key={index}>
+            <S.PathItem>{item}</S.PathItem>
+            {index < pathItems.length - 1 && (
+              <S.PathItem> &gt; </S.PathItem>
+            )}{' '}
+          </React.Fragment>
+        ))}
+      </S.PathWrapper>
+    </S.PathWrapper>
+  );
+}
+
+export default Path;

--- a/src/components/sidebar/Sidebar.styles.tsx
+++ b/src/components/sidebar/Sidebar.styles.tsx
@@ -4,6 +4,7 @@ export const SidebarWrapper = styled.div`
   display: flex;
   flex-direction: column;
   width: 10rem;
+  min-width: 10rem;
   height: calc(100vh - 7rem);
   background: var(--color-white);
   padding: 3rem 2rem;

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,8 +1,10 @@
 import ManageLayout from '@/components/layout/managelayout';
+import Path from '@/components/path';
 
 function Home() {
   return (
     <ManageLayout>
+      <Path />
       <h1>Home</h1>
     </ManageLayout>
   );

--- a/src/pages/sms/Sms.styles.tsx
+++ b/src/pages/sms/Sms.styles.tsx
@@ -1,0 +1,156 @@
+import styled from 'styled-components';
+
+export const SmsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: calc(100vh - 7rem);
+  padding: 4rem;
+  gap: 2.7rem;
+`;
+
+export const Title = styled.h1`
+  color: #000;
+  font-size: 3rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+`;
+
+export const ContentWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  margin-top: 0.5rem;
+  width: 100%;
+  height: 100%;
+  border-radius: 1rem;
+  background: #f9f9f9;
+  padding: 3.5rem 3.5rem 2.2rem;
+  gap: 1.5rem;
+  overflow-y: auto;
+  &::-webkit-scrollbar {
+    width: 0.8rem;
+    height: 0.8rem;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #d1d1d1;
+    border-radius: 0.8rem;
+  }
+  &::-webkit-scrollbar-track {
+    background-color: #fafafa;
+  }
+`;
+
+export const ContentText = styled.p`
+  color: var(--color-black);
+  font-size: 1.8rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 1.792rem;
+`;
+export const Area = styled.div`
+  display: flex;
+  align-items: flex-end;
+  justify-content: flex-start;
+  width: 100%;
+  padding: 1rem;
+`;
+
+export const Bar = styled.div`
+  width: 18.6rem;
+  height: 0.1rem;
+  background: #d7d7d7;
+`;
+
+export const TextArea = styled.textarea`
+  width: 100%;
+  height: 100%;
+  border-radius: 1rem;
+  background: var(--color-white);
+  border: none;
+  outline: none;
+  resize: none;
+  color: #000;
+  font-size: 2rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 1.792rem;
+  padding: 3.3rem 2.6rem;
+  font-family: 'Pretendard', sans-serif;
+  min-height: 46.2rem;
+  &::placeholder {
+    color: #bbb;
+    font-size: 2rem;
+    font-style: normal;
+    font-weight: 500;
+    line-height: 1.792rem;
+  }
+`;
+
+export const SendBtn = styled.button<{ $isDisabled?: boolean }>`
+  display: flex;
+  padding: 1.5rem 3rem;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  border-radius: 1rem;
+  background: ${(props) => (props.$isDisabled ? '#999' : 'var(--color-blue)')};
+  color: var(--color-white);
+  font-size: 1.6rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 1.792rem;
+`;
+
+export const CancelBtn = styled.button`
+  display: flex;
+  padding: 1.5rem 3rem;
+  justify-content: center;
+  align-items: center;
+  border-radius: 1rem;
+  border: 1px solid #d7d7d7;
+  background: var(--color-white);
+  color: #000;
+  font-family: 'Pretendard Variable';
+  font-size: 1.6rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 1.792rem;
+`;
+
+export const BtnArea = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 1rem;
+  height: 4.8rem;
+`;
+
+export const PhraseBtn = styled.button`
+  display: flex;
+  padding: 1rem 2rem;
+  align-items: center;
+  border-radius: 0.5rem;
+  border: 1px solid var(--color-blue);
+  background: var(--color-white);
+  color: var(--color-black);
+  font-size: 1.4rem;
+  font-style: normal;
+  font-weight: 500;
+  line-height: 1.792rem;
+`;
+
+export const RecipientArea = styled.div`
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+`;
+
+export const NameBtn = styled.button`
+  display: flex;
+  width: 9.7rem;
+  padding: 0.5rem 1rem;
+  align-items: flex-start;
+  border-radius: 0.5rem;
+  border: 1px solid #c3c3c3;
+  background: var(--Schemes-On-Error, #fff);
+`;

--- a/src/pages/sms/index.tsx
+++ b/src/pages/sms/index.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import * as S from './Sms.styles';
+
+import Path from '@/components/path';
+import ManageLayout from '@/components/layout/managelayout';
+
+const mockData = [
+  { name: '최준영' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '최준영' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '최준영' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '최준영' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '최준영' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+  { name: '김민수' },
+  { name: '김민지' },
+];
+
+function Sms() {
+  const [message, setMessage] = useState('');
+
+  const handleTextChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    setMessage(e.target.value);
+  };
+  return (
+    <ManageLayout>
+      <S.SmsWrapper>
+        <Path />
+        <S.Title>SMS 보내기</S.Title>
+        <S.ContentWrapper>
+          <S.Area style={{ gap: '2.2rem' }}>
+            <S.ContentText>보내는 사람</S.ContentText>
+            <S.Bar />
+          </S.Area>
+          <S.Area style={{ gap: '3.7rem' }}>
+            <S.ContentText>받는 사람</S.ContentText>
+            <S.Bar />
+          </S.Area>
+          <S.RecipientArea>
+            {mockData.map((data) => (
+              <S.NameBtn>{data.name}</S.NameBtn>
+            ))}
+          </S.RecipientArea>
+          <S.BtnArea>
+            <S.PhraseBtn>자주쓰는문구</S.PhraseBtn>
+          </S.BtnArea>
+          <S.TextArea
+            placeholder='내용을 입력하세요.'
+            value={message}
+            onChange={handleTextChange}
+          />
+          <S.BtnArea>
+            <S.CancelBtn>취소</S.CancelBtn>
+            <S.SendBtn $isDisabled={!message}>전송</S.SendBtn>
+          </S.BtnArea>
+        </S.ContentWrapper>
+      </S.SmsWrapper>
+    </ManageLayout>
+  );
+}
+
+export default Sms;


### PR DESCRIPTION
## 📌 주요 사항
- path 컴포넌트는 학생출결관리, 학생 정보에서까지 작동합니다. 각자 알아서 개발한 url 경로에 맞게 추가해주세요 (자기가 만든 페이지)
- name button은 공통 컴포넌트여서 width만 맞춰서 디자인했습니다
- 옆에 사이드바에 몇학년 몇반 안뜨는 오류 해결했습니다 스크린 샷에는 적용 x

## 📷 스크린샷
sms화면 위 및 경로 알려주는
![sms 전체화면 1](https://github.com/user-attachments/assets/6b8434a4-704f-49c4-a717-7b556c24b346)
sms 화면 아래
![sms 전체화면 2](https://github.com/user-attachments/assets/0f4f45cf-bb00-448b-9abf-13eb6f54df4b)
text area 글 있을시 
![sms 전체화면 글 있는](https://github.com/user-attachments/assets/12d76650-8917-4018-9a5c-0444dd3e1baf)



## 💬 요청사항[선택]



## #️⃣ 연관 이슈번호
이슈를 해결한 경우 👉🏻 close #이슈번호
close #9 