### PR TITLE
feat: 드라이브 레이아웃 및 사이드바 컴포넌트 추가

### DIFF
--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Route, Routes, Navigate } from 'react-router-dom';
 import StudentInfo from './pages/studentInfo';
 import GlobalStyles from './styles/GlobalStyles';
 import Home from './pages/home';
@@ -6,7 +6,7 @@ import Sms from './pages/sms';
 import Attendance from './pages/attendance';
 import Achievement from './pages/achievement';
 import Schedule from './pages/schedule';
-
+import Drive from './pages/drive';
 import Signin from './pages/auth/signin';
 import Signup from './pages/auth/signup';
 import Email from './pages/auth/email';
@@ -43,7 +43,9 @@ export default function Router() {
         <Route path='/manage/studentinfo/:type' element={<StudentInfo />} />
         <Route path='/schedule/*' element={<Schedule />} />
         <Route path='/board' element={<Home />} />
-        <Route path='/drive' element={<Home />} />
+        <Route path='/drive' element={<Navigate to='/drive/my' />} />
+        <Route path='/drive/:type' element={<Drive />} />
+        <Route path="/drive/:type/:subtype?" element={<Drive />} />
       </Routes>
     </BrowserRouter>
   );

--- a/src/components/drivesidebar/DriveSidebar.styles.tsx
+++ b/src/components/drivesidebar/DriveSidebar.styles.tsx
@@ -1,0 +1,73 @@
+import styled from "styled-components";
+
+export const DriveSidebarWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 24rem;
+  min-width: 24rem;
+  height: calc(100vh - 7rem);
+  overflow-y: auto;
+  background: var(--color-white);
+  padding: 3.5rem 0rem;
+  background: #f2f5fc;
+  overflow: visible;
+  &::-webkit-scrollbar {
+    width: 0.8rem;
+    height: 0.8rem;
+  }
+  &::-webkit-scrollbar-thumb {
+    background-color: #d1d1d1;
+    border-radius: 0.8rem;
+  }
+  &::-webkit-scrollbar-track {
+    background-color: #fafafa;
+  }
+`;
+
+export const SidebarItem = styled.div<{ $isSelected?: boolean }>`
+  display: flex;
+  height: 5rem;
+  padding: 1rem 2rem;
+  flex-direction: column;
+  justify-content: center;
+  align-items: flex-start;
+  color: ${(props) =>
+    props.$isSelected ? 'var(--color-white);' : 'var(--color-black);'};
+  font-size: 2.2rem;
+  font-style: normal;
+  font-weight: ${(props) => (props.$isSelected ? 600 : 500)};
+  line-height: 1.792rem;
+  background: ${(props) => (props.$isSelected ? '#0056f6' : 'inherit')};
+  cursor: pointer;
+  min-height: 5rem;
+`;
+
+export const SubSidebarWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  padding: 1rem 2rem;
+  cursor: pointer;
+`;
+
+export const SubSidebarItem = styled.div<{ $isSelected?: boolean }>`
+  display: flex;
+  gap: 0.3rem;
+  height: 5rem;
+  align-items: center;
+  color: ${(props) =>
+    props.$isSelected ? 'var(--color-blue)' : 'var(--color-black)'};
+  font-size: 2rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: 1.792rem;
+  &::before {
+    content: '';
+    width: 0.7rem;
+    height: 0.7rem;
+    border-radius: 50%;
+    background-color: ${(props) =>
+    props.$isSelected ? 'var(--color-blue)' : 'var(--color-black)'};
+    margin-right: 0.8rem;
+  }
+`;

--- a/src/components/drivesidebar/index.tsx
+++ b/src/components/drivesidebar/index.tsx
@@ -1,0 +1,57 @@
+import * as S from './DriveSidebar.styles';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useState } from 'react';
+
+function DriveSidebar() {
+  const navigate = useNavigate();
+  const { type, subtype } = useParams<{ type?: string; subtype?: string }>();
+  const [isTrashExpanded, setIsTrashExpanded] = useState(false);
+
+  const handleTrashClick = () => {
+    setIsTrashExpanded((prev) => !prev);
+    if (!isTrashExpanded) {
+      navigate('/drive/trash/my'); // 기본적으로 개인 휴지통 열기
+    }
+  };
+
+  return (
+    <S.DriveSidebarWrapper>
+      <S.SidebarItem
+        onClick={() => navigate('/drive/my')}
+        $isSelected={type === 'my'}
+      >
+        내 드라이브
+      </S.SidebarItem>
+      <S.SidebarItem
+        onClick={() => navigate('/drive/shared')}
+        $isSelected={type === 'shared'}
+      >
+        공용 드라이브
+      </S.SidebarItem>
+      <S.SidebarItem
+        onClick={handleTrashClick}
+        $isSelected={type === 'trash'}
+      >
+        휴지통
+      </S.SidebarItem>
+      {isTrashExpanded && (
+        <S.SubSidebarWrapper>
+          <S.SubSidebarItem
+            onClick={() => navigate('/drive/trash/my')}
+            $isSelected={type === 'trash' && subtype === 'my'}
+          >
+            개인 휴지통
+          </S.SubSidebarItem>
+          <S.SubSidebarItem
+            onClick={() => navigate('/drive/trash/shared')}
+            $isSelected={type === 'trash' && subtype === 'shared'}
+          >
+            공용 휴지통
+          </S.SubSidebarItem>
+        </S.SubSidebarWrapper>
+      )}
+    </S.DriveSidebarWrapper>
+  );
+};
+
+export default DriveSidebar;

--- a/src/components/layout/drivelayout/DriveLayout.styles.tsx
+++ b/src/components/layout/drivelayout/DriveLayout.styles.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const LayoutContainer = styled.div` 
+  display: flex; 
+  width: 100%; 
+  height: 100%; 
+`;

--- a/src/components/layout/drivelayout/DriveLayout.types.ts
+++ b/src/components/layout/drivelayout/DriveLayout.types.ts
@@ -1,0 +1,3 @@
+export interface DriveLayoutProps {
+  children: React.ReactNode;
+}

--- a/src/components/layout/drivelayout/index.tsx
+++ b/src/components/layout/drivelayout/index.tsx
@@ -1,0 +1,18 @@
+import ScheduleSidebar from "@/components/schedulesidebar";
+import Layout from "..";
+import type { DriveLayoutProps } from './DriveLayout.types';
+import * as S from "./DriveLayout.styles";
+import DriveSidebar from '@/components/drivesidebar';
+
+function DriveLayout({ children }: DriveLayoutProps) {
+  return (
+    <Layout>
+      <S.LayoutContainer>
+        <DriveSidebar />
+        {children}
+      </S.LayoutContainer>
+    </Layout>
+  );
+}
+
+export default DriveLayout;

--- a/src/components/sidebar/index.tsx
+++ b/src/components/sidebar/index.tsx
@@ -42,7 +42,7 @@ function Sidebar() {
           게시판
         </S.SidebarText>
       </S.SidebarItem>
-      <S.SidebarItem onClick={() => navigate('/drive')}>
+      <S.SidebarItem onClick={() => navigate('/drive/my')}>
         <S.Icon src={drive} alt='drive' />
         <S.SidebarText $isSelected={url.startsWith('/drive')}>
           드라이브

--- a/src/pages/drive/drive.styles.tsx
+++ b/src/pages/drive/drive.styles.tsx
@@ -1,0 +1,10 @@
+import styled from 'styled-components';
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  width: 100%;
+  overflow-y: auto;
+  overflow: hidden;
+`;

--- a/src/pages/drive/index.tsx
+++ b/src/pages/drive/index.tsx
@@ -1,0 +1,26 @@
+import DriveLayout from "@/components/layout/drivelayout";
+import { useParams, Navigate } from "react-router-dom";
+import MyDrive from "./myDrive";
+import SharedDrive from "./sharedDrive";
+import MyTrash from "./myTrash";
+import SharedTrash from "./sharedTrash";
+
+function Drive() {
+  const { type, subtype } = useParams<{ type: string; subtype?: string }>();
+
+  return (
+    <DriveLayout>
+      {type === 'my' && <MyDrive />}
+      {type === 'shared' && <SharedDrive />}
+      {type === "trash" && (
+        <>
+          {!subtype && <Navigate to="/drive/trash/my" replace />}
+          {subtype === "my" && <MyTrash />}
+          {subtype === "shared" && <SharedTrash />}
+        </>
+      )}
+    </DriveLayout>
+  )
+}
+
+export default Drive;

--- a/src/pages/drive/myDrive/MyDrive.styles.tsx
+++ b/src/pages/drive/myDrive/MyDrive.styles.tsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  width: 100%;
+  position: relative;
+  flex-grow: 1;
+  padding: 3rem 5rem;
+  overflow-y: auto;
+`;
+
+export const Title = styled.h2`
+  text-align: left;
+  font-size: 2.2rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  margin-bottom: 3rem;
+`;

--- a/src/pages/drive/myDrive/index.tsx
+++ b/src/pages/drive/myDrive/index.tsx
@@ -1,0 +1,14 @@
+import * as PS from '@/pages/drive/drive.styles';
+import * as S from './MyDrive.styles'
+
+function MyDrive() {
+  return (
+    <PS.Container>
+      <S.Container>
+        <S.Title>내 드라이브</S.Title>
+      </S.Container>
+    </PS.Container>
+  );
+}
+
+export default MyDrive;

--- a/src/pages/drive/myTrash/MyTrash.styles.tsx
+++ b/src/pages/drive/myTrash/MyTrash.styles.tsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  width: 100%;
+  position: relative;
+  flex-grow: 1;
+  padding: 3rem 5rem;
+  overflow-y: auto;
+`;
+
+export const Title = styled.h2`
+  text-align: left;
+  font-size: 2.2rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  margin-bottom: 3rem;
+`;

--- a/src/pages/drive/myTrash/index.tsx
+++ b/src/pages/drive/myTrash/index.tsx
@@ -1,0 +1,14 @@
+import * as PS from '@/pages/drive/drive.styles';
+import * as S from './MyTrash.styles';
+
+function MyTrash() {
+  return (
+    <PS.Container>
+      <S.Container>
+        <S.Title>개인 휴지통</S.Title>
+      </S.Container>
+    </PS.Container>
+  )
+}
+
+export default MyTrash;

--- a/src/pages/drive/sharedDrive/SharedDrive.styles.tsx
+++ b/src/pages/drive/sharedDrive/SharedDrive.styles.tsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  width: 100%;
+  position: relative;
+  flex-grow: 1;
+  padding: 3rem 5rem;
+  overflow-y: auto;
+`;
+
+export const Title = styled.h2`
+  text-align: left;
+  font-size: 2.2rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  margin-bottom: 3rem;
+`;

--- a/src/pages/drive/sharedDrive/index.tsx
+++ b/src/pages/drive/sharedDrive/index.tsx
@@ -1,0 +1,14 @@
+import * as PS from '@/pages/drive/drive.styles';
+import * as S from './SharedDrive.styles';
+
+function SharedDrive() {
+  return (
+    <PS.Container>
+      <S.Container>
+        <S.Title>공용 드라이브</S.Title>
+      </S.Container>
+    </PS.Container>
+  );
+}
+
+export default SharedDrive;

--- a/src/pages/drive/sharedTrash/SharedTrash.styles.tsx
+++ b/src/pages/drive/sharedTrash/SharedTrash.styles.tsx
@@ -1,0 +1,18 @@
+import styled from "styled-components";
+
+export const Container = styled.div`
+  width: 100%;
+  position: relative;
+  flex-grow: 1;
+  padding: 3rem 5rem;
+  overflow-y: auto;
+`;
+
+export const Title = styled.h2`
+  text-align: left;
+  font-size: 2.2rem;
+  font-style: normal;
+  font-weight: 600;
+  line-height: normal;
+  margin-bottom: 3rem;
+`;

--- a/src/pages/drive/sharedTrash/index.tsx
+++ b/src/pages/drive/sharedTrash/index.tsx
@@ -1,0 +1,14 @@
+import * as PS from '@/pages/drive/drive.styles';
+import * as S from './SharedTrash.styles';
+
+function SharedTrash() {
+  return (
+    <PS.Container>
+      <S.Container>
+        <S.Title>공용 휴지통</S.Title>
+      </S.Container>
+    </PS.Container>
+  )
+}
+
+export default SharedTrash;


### PR DESCRIPTION
## 📌 주요 사항
- 드라이브 레이아웃
- 드라이브 사이드바
- 드라이브 클릭 시 바로 개인 드라이브로 연결되도록 하였습니다.
- 휴지통 클릭 시 바로 개인 휴지통으로 연결되도록 하였습니다. 

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/792d0208-a94a-43c0-bebb-360520e49511)
![image](https://github.com/user-attachments/assets/1f9a6c53-68e0-4f9f-9fb2-444d08370e0e)


## 💬 요청사항[선택]



## #️⃣ 연관 이슈번호
이슈를 해결한 경우 👉🏻 close #94 